### PR TITLE
Allow configuring Nginx UI port at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM python:3.11-slim
 
 # Install only what you need for runtime
 RUN apt update && apt install -y \
-    nginx iputils-ping traceroute nmap sqlite3 net-tools curl jq \
+    nginx iputils-ping traceroute nmap sqlite3 net-tools curl jq gettext-base \
     && pip install fastapi uvicorn \
     && apt install -y docker.io \
     && apt clean && rm -rf /var/lib/apt/lists/*
@@ -19,8 +19,8 @@ RUN apt update && apt install -y \
 # Remove default Nginx config
 RUN rm -f /etc/nginx/conf.d/default.conf /etc/nginx/sites-enabled/default
 
-# Copy Nginx config and static HTML
-COPY config/nginx/default.conf /etc/nginx/conf.d/default.conf
+# Copy Nginx config template and static HTML
+COPY config/nginx/default.conf.template /config/nginx/default.conf.template
 COPY data/html/ /usr/share/nginx/html/
 
 # Copy scripts, logs, Go binary, FastAPI backend
@@ -34,4 +34,5 @@ RUN chmod +x /config/scripts/*.sh
 # Entrypoint: initializes DB, runs scans, launches FastAPI and Nginx
 CMD ["/config/scripts/atlas_check.sh"]
 
+# Default UI port (override via ATLAS_UI_PORT) and API port
 EXPOSE 8888 8889

--- a/config/nginx/default.conf.template
+++ b/config/nginx/default.conf.template
@@ -1,6 +1,6 @@
 server {
-    listen       8888;
-    listen       [::]:8888;
+    listen       ${ATLAS_UI_PORT};
+    listen       [::]:${ATLAS_UI_PORT};
     server_name  localhost;
 
     location / {

--- a/config/scripts/atlas_check.sh
+++ b/config/scripts/atlas_check.sh
@@ -14,7 +14,10 @@ export PYTHONPATH=/config
 uvicorn scripts.app:app --host 0.0.0.0 --port 8889 > /config/logs/uvicorn.log 2>&1 &
 
 # Start Nginx in the foreground — this keeps the container alive
-log "🌐 Starting Nginx server..."
+ATLAS_UI_PORT=${ATLAS_UI_PORT:-8888}
+log "🌐 Rendering Nginx config for UI port ${ATLAS_UI_PORT}..."
+envsubst '${ATLAS_UI_PORT}' < /config/nginx/default.conf.template > /etc/nginx/conf.d/default.conf
+log "🌐 Starting Nginx server on port ${ATLAS_UI_PORT}..."
 nginx -g "daemon off;" &
 
 NGINX_PID=$!

--- a/config/scripts/atlas_check.sh
+++ b/config/scripts/atlas_check.sh
@@ -15,6 +15,7 @@ uvicorn scripts.app:app --host 0.0.0.0 --port 8889 > /config/logs/uvicorn.log 2>
 
 # Start Nginx in the foreground — this keeps the container alive
 ATLAS_UI_PORT=${ATLAS_UI_PORT:-8888}
+export ATLAS_UI_PORT
 log "🌐 Rendering Nginx config for UI port ${ATLAS_UI_PORT}..."
 envsubst '${ATLAS_UI_PORT}' < /config/nginx/default.conf.template > /etc/nginx/conf.d/default.conf
 log "🌐 Starting Nginx server on port ${ATLAS_UI_PORT}..."


### PR DESCRIPTION
## Summary
- add an nginx configuration template that supports runtime port substitution and install envsubst in the image
- render the nginx config during container start to honor ATLAS_UI_PORT and log the configured port
- update Dockerfile comments to highlight the default UI port

## Testing
- bash -n config/scripts/atlas_check.sh


------
https://chatgpt.com/codex/tasks/task_e_68d197c34a248330a25bed3ffa50b290