### PR TITLE
Update ARM64 runtime to render nginx config at startup

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -72,6 +72,7 @@ RUN apt-get update \
         net-tools \
         curl \
         jq \
+        gettext-base \
         docker.io \
     && pip install --no-cache-dir fastapi uvicorn \
     && apt-get clean \
@@ -80,14 +81,15 @@ RUN apt-get update \
 # Remove default Nginx configuration
 RUN rm -f /etc/nginx/conf.d/default.conf /etc/nginx/sites-enabled/default
 
-# Copy Nginx config
-COPY config/nginx/default.conf /etc/nginx/conf.d/default.conf
-
 # Copy runtime scripts and Go binary
 COPY config/scripts /config/scripts
 RUN mkdir -p /config/bin
 COPY --from=go-builder /app/atlas/atlas /config/bin/atlas
 RUN chmod +x /config/scripts/*.sh
+
+# Copy Nginx configuration template
+RUN mkdir -p /config/nginx
+COPY config/nginx/default.conf.template /config/nginx/default.conf.template
 
 # Copy freshly built UI into Nginx web root
 RUN mkdir -p /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- install gettext-base in the ARM64 runtime image so envsubst is available
- copy the nginx default.conf template into /config/nginx and let the entrypoint render it at runtime

## Testing
- `docker build -f Dockerfile.arm64 -t atlas-arm64-test .` *(fails: docker command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d271afd8548330927438d36718a494